### PR TITLE
ci(release): add quality and TLS gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,52 @@
+name: Python quality
+
+on:
+  pull_request:
+  push:
+    branches:
+      - develop
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+  quality:
+    name: Quality (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.12", "3.13"]
+    steps:
+      - name: Check out source
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Set up pinned uv
+        uses: astral-sh/setup-uv@f0ec1fc3b38f5e7cd731bb6ce540c5af426746bb # v6.1.0
+        with:
+          version: "0.7.22"
+
+      - name: Install the frozen dependency graph
+        run: uv sync --frozen --all-groups
+
+      - name: Run tests
+        run: uv run --frozen --no-sync pytest
+
+      - name: Run Ruff
+        run: uv run --frozen --no-sync ruff check src tests
+
+      - name: Run mypy
+        run: uv run --frozen --no-sync mypy
+
+      - name: Check lockfile
+        run: uv lock --check
+
+      - name: Build distributions
+        run: uv build

--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ config.*.yaml
 *api*key*
 *api*token*
 *secret*
+!scripts/run_history_secret_scan.py
 !.secrets.baseline
 *password*
 *credential*

--- a/docs/security-compliance.md
+++ b/docs/security-compliance.md
@@ -20,6 +20,9 @@ or institutional compliance assessment.
 - Archive/member/path, digest, signature, and staging checks for bundles.
 - Focused abuse tests for malformed URLs, raw-resource limits, source transport,
   malicious bundles, and research-safety language.
+- The general quality workflow runs frozen tests, Ruff, mypy, lock validation,
+  and package builds across Python 3.12 and 3.13; this is engineering evidence,
+  not scientific validation or release authorization.
 - A locked runtime dependency audit and reviewed secret-detection workflow in
   continuous integration configuration.
 

--- a/scripts/run_history_secret_scan.py
+++ b/scripts/run_history_secret_scan.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Run the repository's pinned-config Gitleaks history scan."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+from pathlib import Path
+
+_REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+_CONFIG_PATH = _REPOSITORY_ROOT / ".gitleaks.toml"
+
+
+def _history_range(
+    repository: Path,
+    *,
+    before: str | None,
+    head: str,
+    base_ref: str | None,
+) -> str:
+    if base_ref:
+        completed = subprocess.run(
+            ["git", "merge-base", base_ref, head],
+            cwd=repository,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if completed.returncode != 0:
+            raise RuntimeError(f"Unable to determine merge base for {base_ref}")
+        return f"{completed.stdout.strip()}..{head}"
+    if before and before != "0" * 40:
+        return f"{before}..{head}"
+    return "--all"
+
+
+def run_history_scan(
+    repository: Path,
+    *,
+    before: str | None = None,
+    head: str = "HEAD",
+    base_ref: str | None = None,
+) -> subprocess.CompletedProcess[bytes]:
+    """Scan the selected repository history with the shared Gitleaks policy."""
+    command = os.environ.get("GITLEAKS_COMMAND", "gitleaks")
+    log_options = _history_range(
+        repository,
+        before=before,
+        head=head,
+        base_ref=base_ref,
+    )
+    return subprocess.run(
+        [
+            command,
+            "git",
+            "--no-banner",
+            "--config",
+            str(_CONFIG_PATH),
+            f"--log-opts={log_options}",
+            str(repository),
+        ],
+        check=False,
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repository", type=Path, default=_REPOSITORY_ROOT)
+    parser.add_argument("--before")
+    parser.add_argument("--head", default="HEAD")
+    parser.add_argument("--base-ref")
+    arguments = parser.parse_args()
+    return run_history_scan(
+        arguments.repository,
+        before=arguments.before,
+        head=arguments.head,
+        base_ref=arguments.base_ref,
+    ).returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/contract/test_ci_workflow.py
+++ b/tests/contract/test_ci_workflow.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = ROOT / ".github" / "workflows" / "ci.yml"
+
+
+def test_ci_workflow_exposes_the_locked_python_quality_gate() -> None:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "pull_request:" in workflow
+    assert "      - develop" in workflow
+    assert "      - master" in workflow
+    assert 'python-version: ["3.12", "3.13"]' in workflow
+    assert "permissions:\n  contents: read" in workflow
+
+    for command in (
+        "uv sync --frozen --all-groups",
+        "uv run --frozen --no-sync pytest",
+        "uv run --frozen --no-sync ruff check src tests",
+        "uv run --frozen --no-sync mypy",
+        "uv lock --check",
+        "uv build",
+    ):
+        assert command in workflow

--- a/tests/integration/bundles/test_transport_https.py
+++ b/tests/integration/bundles/test_transport_https.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import socket
+import ssl
+from datetime import UTC, datetime, timedelta
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from threading import Thread
+
+import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import NameOID
+
+
+def _write_test_certificate(directory: Path, hostname: str) -> tuple[Path, Path]:
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, hostname)])
+    now = datetime.now(UTC)
+    certificate = (
+        x509.CertificateBuilder()
+        .subject_name(name)
+        .issuer_name(name)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - timedelta(minutes=1))
+        .not_valid_after(now + timedelta(days=1))
+        .add_extension(
+            x509.SubjectAlternativeName([x509.DNSName(hostname)]), critical=False
+        )
+        .sign(key, hashes.SHA256())
+    )
+    certificate_path = directory / "server.crt"
+    key_path = directory / "server.key"
+    certificate_path.write_bytes(certificate.public_bytes(serialization.Encoding.PEM))
+    key_path.write_bytes(
+        key.private_bytes(
+            serialization.Encoding.PEM,
+            serialization.PrivateFormat.TraditionalOpenSSL,
+            serialization.NoEncryption(),
+        )
+    )
+    return certificate_path, key_path
+
+
+def _bundle_handler(payload: bytes) -> type[BaseHTTPRequestHandler]:
+    class BundleHandler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:
+            self.send_response(200)
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+
+        def log_message(self, format: str, *args: object) -> None:
+            del format, args
+
+    return BundleHandler
+
+
+def test_download_uses_pinned_https_connection_end_to_end(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from acmg_classifier.infrastructure.bundles import transport
+
+    hostname = "bundles.example.test"
+    pinned_address = "93.184.216.34"
+    payload = b"bundle-bytes"
+    certificate_path, key_path = _write_test_certificate(tmp_path, hostname)
+
+    server_context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    server_context.load_cert_chain(certificate_path, key_path)
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _bundle_handler(payload))
+    server.socket = server_context.wrap_socket(server.socket, server_side=True)
+    server_thread = Thread(target=server.serve_forever)
+    server_thread.start()
+
+    original_create_context = ssl.create_default_context
+    original_create_connection = transport.socket.create_connection
+    original_getaddrinfo = transport.socket.getaddrinfo
+    connection_attempts: list[tuple[str, int]] = []
+
+    def resolve(
+        host: str, port: int, *args: object, **kwargs: object
+    ) -> list[tuple[object, ...]]:
+        if host == hostname:
+            return [
+                (
+                    transport.socket.AF_INET,
+                    transport.socket.SOCK_STREAM,
+                    transport.socket.IPPROTO_TCP,
+                    "",
+                    (pinned_address, port),
+                )
+            ]
+        return original_getaddrinfo(host, port, *args, **kwargs)
+
+    def connect(
+        address: tuple[str, int],
+        timeout: float | None = None,
+        source_address: tuple[str, int] | None = None,
+    ) -> socket.socket:
+        connection_attempts.append(address)
+        if address[0] == pinned_address:
+            address = ("127.0.0.1", address[1])
+        return original_create_connection(
+            address, timeout=timeout, source_address=source_address
+        )
+
+    client_context = original_create_context(cafile=str(certificate_path))
+    monkeypatch.setattr(transport.ssl, "create_default_context", lambda: client_context)
+    monkeypatch.setattr(transport.socket, "getaddrinfo", resolve)
+    monkeypatch.setattr(transport.socket, "create_connection", connect)
+
+    progress: list[transport.ProgressEvent] = []
+    destination = tmp_path / "bundle.bin"
+    try:
+        downloader = transport.HttpDownloadTransport(
+            timeout_seconds=5,
+            chunk_size=3,
+            max_download_bytes=len(payload),
+        )
+        downloader.download(
+            f"https://{hostname}:{server.server_port}/bundle",
+            destination,
+            offset=0,
+            progress=progress.append,
+        )
+    finally:
+        server.shutdown()
+        server.server_close()
+        server_thread.join(timeout=5)
+
+    assert not server_thread.is_alive()
+    assert destination.read_bytes() == payload
+    assert connection_attempts == [(pinned_address, server.server_port)]
+    assert progress
+    assert progress[-1].completed_bytes == len(payload)
+    assert progress[-1].total_bytes == len(payload)


### PR DESCRIPTION
## Summary
- Add a locked Python quality workflow for pull requests and protected branches.
- Add end-to-end local TLS coverage for pinned bundle downloads.
- Track the shared history-scan helper so the security action works from clean checkouts.

## Motivation
The repository had strong local verification but no general CI quality gate. The security workflow also failed in clean GitHub checkouts because `scripts/verify_history_scan_regression.py` imported a helper excluded by the broad `*secret*` ignore rule.

## Changes

### Added
- `.github/workflows/ci.yml` with Python 3.12/3.13 test, Ruff, mypy, lockfile, and build jobs.
- CI workflow contract coverage.
- Real local HTTPS/TLS integration coverage for the pinned bundle downloader.
- The tracked `scripts/run_history_secret_scan.py` helper.

### Changed
- Allow the history-scan helper through `.gitignore`.
- Document CI and TLS engineering evidence without changing the project's research-only release status.

## Testing
- [x] Full pytest suite: 484 passed with resource warnings treated as errors.
- [x] History-scan security tests: 15 passed.
- [x] Tracked secret scan passed with the reviewed baseline.
- [x] Ruff passed for `src`, `tests`, and the history-scan helper.
- [x] Mypy passed.
- [x] `uv lock --check` passed.
- [x] `uv build` passed.
- [x] Local reproduction of the GitHub history-scan regression passed after tracking the helper.

## Checklist
- [x] Code follows project conventions.
- [x] Tests added or updated.
- [x] Documentation updated.
- [x] No scientific or stable-release claims added.
- [x] Security considerations reviewed.

## Release note
This PR improves engineering and CI evidence only. It does not create a release tag or claim scientific validation, certification, or stable release readiness.
